### PR TITLE
fix for deprecated docstring rendering in openfe

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,9 +12,11 @@ package:
 source:
   url: https://github.com/OpenFreeEnergy/${{ name }}/archive/refs/tags/v${{ version }}.tar.gz
   sha256: 9b2846625c50bffdf87bc6985e2571b242eb0ec67c8bef200653af1caafa30a9
+  patches:
+    - version-deprecated-803.patch  # fixes openfe docs build
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: SETUPTOOLS_SCM_PRETEND_VERSION=${{ version }} ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 

--- a/recipe/version-deprecated-803.patch
+++ b/recipe/version-deprecated-803.patch
@@ -1,0 +1,25 @@
+From 9d4aa7175f8dbc6fd6d99fedd39e39f017782c3e Mon Sep 17 00:00:00 2001
+From: Alyssa Travitz <31974495+atravitz@users.noreply.github.com>
+Date: Wed, 24 Jun 2026 14:43:34 -0700
+Subject: [PATCH] version-deprecated -> deprecated (#803)
+
+---
+ src/gufe/ligandnetwork.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/gufe/ligandnetwork.py b/src/gufe/ligandnetwork.py
+index 8068d69..539f300 100644
+--- a/src/gufe/ligandnetwork.py
++++ b/src/gufe/ligandnetwork.py
+@@ -318,7 +318,7 @@ class LigandNetwork(GufeTokenizable):
+     ) -> gufe.AlchemicalNetwork:
+         """Create an :class:`.AlchemicalNetwork` from this :class:`.LigandNetwork`.
+ 
+-        .. version-deprecated:: 1.8.0
++        .. deprecated:: 1.8.0
+             This function is deprecated and will be removed in version 1.13.0.
+ 
+         Parameters
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

This only touches the docstring, so IMO doesn't warrant a bugfix release: https://github.com/OpenFreeEnergy/gufe/pull/803

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
